### PR TITLE
internal/k8sutil: dont overwrite local Node during update

### DIFF
--- a/internal/k8sutil/metadata.go
+++ b/internal/k8sutil/metadata.go
@@ -50,7 +50,7 @@ func updateNodeRetry(nc v1core.NodeInterface, node string, f func(*v1api.Node)) 
 	f(n)
 
 	err = RetryOnConflict(DefaultBackoff, func() (err error) {
-		n, err = nc.Update(n)
+		_, err = nc.Update(n)
 		return
 	})
 	if err != nil {


### PR DESCRIPTION
if update fails, the local n variable is overwritten with an zero-valued
struct, causing spurious 'resource name may not be empty'