### PR TITLE
build/*: Add build scripts to build docker images with commit hash.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
-IMAGE	?= quay.io/coreos/container-linux-update-operator
-TAG	?= dev
+.PHONY:	all bin precompile image clean
 
-all:	bin image
+all:	bin
 
 bin:	bin/update-agent bin/update-operator
 
 bin/%:
-	CGO_ENABLED=0 go build -ldflags '-s -w' -tags netgo -v -o $@ ./cmd/$*
+	CGO_ENABLED=0 go build -ldflags '-s -w' -tags netgo -o $@ ./cmd/$*
 
 precompile:
-	CGO_ENABLED=0 go test -i -tags netgo -v ./cmd/...
+	CGO_ENABLED=0 go test -i -tags netgo ./cmd/...
 
 image:
-	docker build -t $(IMAGE):$(TAG) -f Dockerfile .
+	./build/build-image.sh
 
 clean:
 	rm -rf bin
@@ -21,6 +20,3 @@ test:
 	CGO_ENABLED=0 go test -tags netgo -v ./internal/...
 
 integration-test:
-
-.PHONY:	all bin precompile image clean
-

--- a/build/build-image.sh
+++ b/build/build-image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_REPO=${IMAGE_REPO:-quay.io/coreos/container-linux-update-operator}
+
+readonly REPO_ROOT=$(git rev-parse --show-toplevel)
+readonly VERSION=${VERSION:-$(${REPO_ROOT}/build/git-version.sh)}
+
+sudo rkt run --uuid-file-save=rkt.uuid \
+    --volume repo-root,kind=host,source=${REPO_ROOT} \
+    --mount volume=repo-root,target=/go/src/github.com/coreos-inc/container-linux-update-operator \
+    --insecure-options=image docker://golang:1.7.3 --exec /bin/bash -- -c \
+    "cd /go/src/github.com/coreos-inc/container-linux-update-operator && make clean test all"
+
+sudo rkt rm --uuid-file=rkt.uuid
+rm -f rkt.uuid
+
+cd ${REPO_ROOT} && docker build -t ${IMAGE_REPO}:${VERSION} .
+
+if [[ ${PUSH_IMAGE:-false} == "true" ]]; then
+    docker push ${IMAGE_REPO}:${VERSION}
+fi

--- a/build/git-version.sh
+++ b/build/git-version.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+# parse the current git commit hash
+COMMIT=$(git rev-parse HEAD)
+
+# check if the current commit has a matching tag
+TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
+
+# use the matching tag as the version, if available
+if [ -z "$TAG" ]; then
+    VERSION=$COMMIT
+else
+    VERSION=$TAG
+fi
+
+# check for changed files (not untracked files)
+if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
+    VERSION="${VERSION}-dirty"
+fi
+
+echo $VERSION


### PR DESCRIPTION
This makes the image build process identical to tco and kvo.
A new jenkins job is created as well: https://jenkins.coreos.systems/view/Kubernetes/job/container-linux-update-operator-image-builder/

cc @aaronlevy @derekparker 