### PR TITLE
operator/build: fix tagging consistency

### DIFF
--- a/pkg/operator/agent_manager.go
+++ b/pkg/operator/agent_manager.go
@@ -220,7 +220,7 @@ func agentDaemonsetSpec(repo string) *v1beta1.DaemonSet {
 }
 
 func agentImageName(repo string) string {
-	return fmt.Sprintf("%s:%s", repo, version.Version)
+	return fmt.Sprintf("%s:v%s", repo, version.Version)
 }
 
 func agentCommand() []string {


### PR DESCRIPTION
cc @dghubble, this is the proper fix for the problem we ran into on the installer.
Specifically, the first commit.

The other two are build improvements that are somewhat related, but not all that much.