### PR TITLE
pkg/agent: avoid exiting on watch termination

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -191,7 +191,8 @@ func (k *Klocksmith) Run() error {
 	for _, pod := range pods {
 		glog.Infof("Terminating pod %q...", pod.Name)
 		if err := k.kc.Pods(pod.Namespace).Delete(pod.Name, deleteOptions); err != nil {
-			return fmt.Errorf("failed terminating pod %q: %v", pod.Name, err)
+			glog.Errorf("failed terminating pod %q: $v", pod.Name, err)
+			// Continue anyways, the reboot should terminate it
 		}
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -145,9 +145,14 @@ func (k *Klocksmith) Run() error {
 	go k.watchUpdateStatus(k.updateStatusCallback)
 
 	// block until constants.AnnotationOkToReboot is set
-	glog.Infof("Waiting for ok-to-reboot from controller...")
-	if err := k.waitForOkToReboot(); err != nil {
-		return err
+	for {
+		glog.Infof("Waiting for ok-to-reboot from controller...")
+		err := k.waitForOkToReboot()
+		if err == nil {
+			// time to reboot
+			break
+		}
+		glog.Warningf("error waiting for an ok-to-reboot: %v", err)
 	}
 
 	// set constants.AnnotationRebootInProgress and drain self


### PR DESCRIPTION
Works around #75. Properly, it would also distinguish between
"retryable" and "unretryable" errors, but client-go doesn't give us
great granularity.

In the future, adding further granularity would be a good idea.

This also tweaks whether delete failures are fatal based on a discussion @aaronlevy and I had a while ago.

cc @dghubble 

Testing done: none yet 😦 