### PR TITLE
examples: Disable manage-agent feature in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,12 @@ To start/stop a service, run `systemctl start <name>` or `systemctl stop <name>`
 
 ## Usage
 
-To start the `update-operator` Deployment, run:
+Create the `update-operator` deployment and `update-agent` daemonset.
 
 ```
 kubectl create -f examples/update-operator.yaml
+kubectl create -f example/update-agent.yaml
 ```
-
-By default, the `update-operator` will manage the `update-agent` DaemonSet on your
-behalf. It also uses the `latest` image tag, which you can swap if necessary.
 
 ## Test
 

--- a/build/bump-release
+++ b/build/bump-release
@@ -32,7 +32,9 @@ NEXT_VERSION=$(echo "${VERSION}" | awk -F. '{print $1"."$2+1".0"}') #x.y.z
 echo "${VERSION}" > VERSION
 git add VERSION
 envsubst '${VERSION}' < examples/update-operator.yaml.tmpl > examples/update-operator.yaml
+envsubst '${VERSION}' < examples/update-agent.yaml.tmpl > examples/update-agent.yaml
 git add examples/update-operator.yaml
+git add examples/update-agent.yaml
 
 git commit -m "version: bump to v${VERSION}"
 git tag --sign "v${VERSION}" -m "v${VERSION}"

--- a/examples/update-agent.yaml
+++ b/examples/update-agent.yaml
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: container-linux-update-agent
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: container-linux-update-agent
+        container-linux-update.v1.coreos.com/agent-version: v0.2.1
+      annotations:
+        container-linux-update.v1.coreos.com/agent-version: v0.2.1
+    spec:
+      containers:
+      - name: update-agent
+        image: quay.io/coreos/container-linux-update-operator:v0.2.1
+        command:
+        - "/bin/update-agent"
+        volumeMounts:
+          - mountPath: /var/run/dbus
+            name: var-run-dbus
+          - mountPath: /etc/coreos
+            name: etc-coreos
+          - mountPath: /usr/share/coreos
+            name: usr-share-coreos
+          - mountPath: /etc/os-release
+            name: etc-os-release
+        env:
+        # read by update-agent as the node name to manage reboots for
+        - name: UPDATE_AGENT_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      volumes:
+      - name: var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: etc-coreos
+        hostPath:
+          path: /etc/coreos
+      - name: usr-share-coreos
+        hostPath:
+          path: /usr/share/coreos
+      - name: etc-os-release
+        hostPath:
+          path: /etc/os-release

--- a/examples/update-agent.yaml.tmpl
+++ b/examples/update-agent.yaml.tmpl
@@ -1,0 +1,51 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: container-linux-update-agent
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: container-linux-update-agent
+        container-linux-update.v1.coreos.com/agent-version: v${VERSION}
+      annotations:
+        container-linux-update.v1.coreos.com/agent-version: v${VERSION}
+    spec:
+      containers:
+      - name: update-agent
+        image: quay.io/coreos/container-linux-update-operator:v${VERSION}
+        command:
+        - "/bin/update-agent"
+        volumeMounts:
+          - mountPath: /var/run/dbus
+            name: var-run-dbus
+          - mountPath: /etc/coreos
+            name: etc-coreos
+          - mountPath: /usr/share/coreos
+            name: usr-share-coreos
+          - mountPath: /etc/os-release
+            name: etc-os-release
+        env:
+        # read by update-agent as the node name to manage reboots for
+        - name: UPDATE_AGENT_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      volumes:
+      - name: var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: etc-coreos
+        hostPath:
+          path: /etc/coreos
+      - name: usr-share-coreos
+        hostPath:
+          path: /usr/share/coreos
+      - name: etc-os-release
+        hostPath:
+          path: /etc/os-release

--- a/examples/update-operator.yaml
+++ b/examples/update-operator.yaml
@@ -15,6 +15,7 @@ spec:
         image: quay.io/coreos/container-linux-update-operator:v0.2.1
         command:
         - "/bin/update-operator"
+        - "--manage-agent=false"
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/examples/update-operator.yaml.tmpl
+++ b/examples/update-operator.yaml.tmpl
@@ -15,6 +15,7 @@ spec:
         image: quay.io/coreos/container-linux-update-operator:v${VERSION}
         command:
         - "/bin/update-operator"
+        - "--manage-agent=false"
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
Examples should show deploying the `update-operator` (coordinator) deployment and `update-agent` daemonset directly. The `manage-agent` feature is disabled according to plans outlined in #98

Note: Tectonic is still using the manage-agent feature so it hasn't been removed.