### PR TITLE
examples: Add update-agent NoSchedule toleration

### DIFF
--- a/examples/update-agent.yaml
+++ b/examples/update-agent.yaml
@@ -36,6 +36,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       volumes:
       - name: var-run-dbus
         hostPath:

--- a/examples/update-agent.yaml.tmpl
+++ b/examples/update-agent.yaml.tmpl
@@ -36,6 +36,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       volumes:
       - name: var-run-dbus
         hostPath:


### PR DESCRIPTION
* Allow update-agent to run on nodes with a NodeSchedule taint, a common taint used for workload isolation
* Users deploying to clusters that use their own taints should adapt the tolerations in the examples according to their needs
