### PR TITLE
cmd/update-operator: Mark manage-agent deprecated

### DIFF
--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -15,9 +15,10 @@ import (
 
 var (
 	analyticsEnabled = flag.Bool("analytics", true, "Send analytics to Google Analytics")
-	manageAgent      = flag.Bool("manage-agent", true, "Manage the associated update-agent")
-	agentImageRepo   = flag.String("agent-image-repo", "quay.io/coreos/container-linux-update-operator", "The image to use for the managed agent, without version tag")
 	printVersion     = flag.Bool("version", false, "Print version and exit")
+	// deprecated
+	manageAgent    = flag.Bool("manage-agent", false, "Manage the associated update-agent")
+	agentImageRepo = flag.String("agent-image-repo", "quay.io/coreos/container-linux-update-operator", "The image to use for the managed agent, without version tag")
 )
 
 func main() {
@@ -37,6 +38,10 @@ func main() {
 		analytics.Enable()
 	}
 
+	if *manageAgent {
+		glog.Warning("Use of -manage-agent=true is deprecated and will be removed in the future")
+	}
+
 	o, err := operator.New(operator.Config{
 		ManageAgent:    *manageAgent,
 		AgentImageRepo: *agentImageRepo,
@@ -54,6 +59,6 @@ func main() {
 	defer close(stop)
 
 	if err := o.Run(stop); err != nil {
-		glog.Fatalf("error while running %s: %v", os.Args[0], err)
+		glog.Fatalf("Error while running %s: %v", os.Args[0], err)
 	}
 }


### PR DESCRIPTION
I've updated the example manifests to always set `manage-agent` to false, per design discussions in #98 and #76.

Change `manage-agent` to default to false and show a warning when set to true since this is not the way we want to go going forward. Tectonic has a corresponding change to explicitly request the old behavior until a migration plan is ready. https://github.com/coreos/tectonic-installer/pull/1250

```
W0629 18:35:46.145820       1 main.go:43] use of -manage-agent=true is deprecated and will be removed in the future
I0629 18:35:46.148454       1 main.go:51] /bin/update-operator running
I0629 18:35:46.180891       1 leaderelection.go:179] attempting to acquire leader lease...
```