### PR TITLE
agent: moved getting first ue status to RecieveStatuses func

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -219,14 +219,6 @@ func (k *Klocksmith) watchUpdateStatus(update func(s updateengine.Status), stop 
 
 	go k.ue.ReceiveStatuses(ch, stop)
 
-	// synthesize first message
-	st, err := k.ue.GetStatus()
-	if err != nil {
-		glog.Fatalf("Failed to get update_engine status: %v", err)
-	}
-
-	ch <- st
-
 	for status := range ch {
 		if status.CurrentOperation != oldOperation && update != nil {
 			update(status)

--- a/pkg/updateengine/client.go
+++ b/pkg/updateengine/client.go
@@ -80,7 +80,16 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// ReceiveStatuses receives signal messages from dbus and sends them as Statues
+// on the rcvr channel, until the stop channel is closed. An attempt is made to
+// get the initial status and send it on the rcvr channel before receiving
+// starts.
 func (c *Client) ReceiveStatuses(rcvr chan Status, stop <-chan struct{}) {
+	// if there is an error getting the current status, ignore it and just
+	// move onto the main loop.
+	st, _ := c.GetStatus()
+	rcvr <- st
+
 	for {
 		select {
 		case <-stop:
@@ -105,6 +114,7 @@ func (c *Client) RebootNeededSignal(rcvr chan Status, stop <-chan struct{}) {
 	}
 }
 
+// GetStatus gets the current status from update_engine
 func (c *Client) GetStatus() (result Status, err error) {
 	call := c.object.Call(dbusInterface+".GetStatus", 0)
 	err = call.Err


### PR DESCRIPTION
Generating a status and putting it in our channel would deadlock if there was
already a ue status update waiting for us, which happens when a signal comes
along between the time we subscribe in New() and the time we actually start
consuming status updates. Instead, make the go routine do the first status
signal synthesis for us, and the problem goes away.