### PR TITLE
Use controller pattern for update-agent

### DIFF
--- a/cmd/update-agent/main.go
+++ b/cmd/update-agent/main.go
@@ -41,7 +41,8 @@ func main() {
 
 	glog.Infof("%s running", os.Args[0])
 
-	if err := a.Run(); err != nil {
-		glog.Fatalf("Error while running %s: %v", os.Args[0], err)
-	}
+	// Run agent until the stop channel is closed
+	stop := make(chan struct{})
+	defer close(stop)
+	a.Run(stop)
 }


### PR DESCRIPTION
Pass in a top-level stop channel to the agent operator to use when it launches goroutines or calls `time.Sleep`. In theory, if we trapped on signals in cmd, we'd see every goroutine stop and a clean "Stopping agent" log line.

A general controller:

```
New(config Config) (*Kontroller)

func (k *Kontroller) Run(stop <-chan struct{}) {
  // starting
  wait.Until(processLoop, period, stop)
  // stopping
}

func (k.Kontroller) process() {
  // reconciliation logic
}
```

Similar to #108