### PR TITLE
Auto-label Container Linux nodes with update-agent label

### DIFF
--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -15,9 +15,10 @@ import (
 )
 
 var (
-	kubeconfig       = flag.String("kubeconfig", "", "Path to a kubeconfig file. Default to the in-cluster config if not provided.")
-	analyticsEnabled = flag.Bool("analytics", true, "Send analytics to Google Analytics")
-	printVersion     = flag.Bool("version", false, "Print version and exit")
+	kubeconfig              = flag.String("kubeconfig", "", "Path to a kubeconfig file. Default to the in-cluster config if not provided.")
+	analyticsEnabled        = flag.Bool("analytics", true, "Send analytics to Google Analytics")
+	autoLabelContainerLinux = flag.Bool("auto-label-container-linux", false, "Auto-label Container Linux nodes with agent=true (convenience)")
+	printVersion            = flag.Bool("version", false, "Print version and exit")
 	// deprecated
 	manageAgent    = flag.Bool("manage-agent", false, "Manage the associated update-agent")
 	agentImageRepo = flag.String("agent-image-repo", "quay.io/coreos/container-linux-update-operator", "The image to use for the managed agent, without version tag")
@@ -56,9 +57,10 @@ func main() {
 
 	// update-operator
 	o, err := operator.New(operator.Config{
-		Client:         client,
-		ManageAgent:    *manageAgent,
-		AgentImageRepo: *agentImageRepo,
+		Client:                  client,
+		AutoLabelContainerLinux: *autoLabelContainerLinux,
+		ManageAgent:             *manageAgent,
+		AgentImageRepo:          *agentImageRepo,
 	})
 	if err != nil {
 		glog.Fatalf("Failed to initialize %s: %v", os.Args[0], err)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -62,6 +62,10 @@ const (
 	// Key set by the update-agent to the value of "VERSION" in /etc/os-release.
 	LabelVersion = Prefix + "version"
 
+	// Label set to "true" on nodes where update-agent pods should be scheduled.
+	// This applies only when update-operator is run with manage-agent=true.
+	LabelUpdateAgentEnabled = Prefix + "agent"
+
 	// AgentVersion is the key used to indicate the
 	// container-linux-update-operator's agent's version.
 	// The value is a semver-parseable string. It should be present on each agent

--- a/pkg/k8sutil/selector.go
+++ b/pkg/k8sutil/selector.go
@@ -1,7 +1,10 @@
 package k8sutil
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	v1api "k8s.io/client-go/pkg/api/v1"
 )
 
@@ -17,4 +20,30 @@ func FilterNodesByAnnotation(list []v1api.Node, sel fields.Selector) []v1api.Nod
 	}
 
 	return ret
+}
+
+// FilterNodesByRequirement filters a list of nodes and returns nodes matching the
+// given label requirement.
+func FilterNodesByRequirement(nodes []v1api.Node, req *labels.Requirement) []v1api.Node {
+	var matches []v1api.Node
+
+	for _, node := range nodes {
+		if req.Matches(labels.Set(node.Labels)) {
+			matches = append(matches, node)
+		}
+	}
+	return matches
+}
+
+// FilterContainerLinuxNodes filters a list of nodes and returns nodes with a
+// Container Linux OSImage, as reported by the node's /etc/os-release.
+func FilterContainerLinuxNodes(nodes []v1api.Node) []v1api.Node {
+	var matches []v1api.Node
+
+	for _, node := range nodes {
+		if strings.HasPrefix(node.Status.NodeInfo.OSImage, "Container Linux") {
+			matches = append(matches, node)
+		}
+	}
+	return matches
 }


### PR DESCRIPTION
*Note: Direct users of CLUO should use `-manage-agent=false` as shown in examples. Deploy the `update-agent` daemonset to select nodes in any way desired. CLUO is not opinionated.*

Background: When the update-operator is run with `manage-agent=true (dprecated)`, the operator creates update-agent as a daemonset across all nodes. We're migrating toward creating a daemonset which has a node selector so admins always have control. #76

When `-manage-agent=true`:

* Auto-label Container Linux nodes which lack the label `container-linux-update.v1.coreos.com/agent` with `container-linux-update.v1.coreos.com/agent=true`
* Don't auto-label nodes running non Container Linux distros
* Admins may set label `container-linux-update.v1.coreos.com/agent=false`
* Ignore nodes once the `container-linux-update.v1.coreos.com/agent` label exists
* A followup migration (external) may switch the update-agent Daemonset to select nodes which have `agent=true` in order to migrate.