### PR TITLE
examples: Add rolling update strategy and remove label/annotation

### DIFF
--- a/examples/update-agent.yaml
+++ b/examples/update-agent.yaml
@@ -4,13 +4,14 @@ metadata:
   name: container-linux-update-agent
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
         app: container-linux-update-agent
-        container-linux-update.v1.coreos.com/agent-version: v0.2.2
-      annotations:
-        container-linux-update.v1.coreos.com/agent-version: v0.2.2
     spec:
       containers:
       - name: update-agent

--- a/examples/update-agent.yaml.tmpl
+++ b/examples/update-agent.yaml.tmpl
@@ -4,13 +4,14 @@ metadata:
   name: container-linux-update-agent
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
         app: container-linux-update-agent
-        container-linux-update.v1.coreos.com/agent-version: v${VERSION}
-      annotations:
-        container-linux-update.v1.coreos.com/agent-version: v${VERSION}
     spec:
       containers:
       - name: update-agent

--- a/examples/update-operator.yaml
+++ b/examples/update-operator.yaml
@@ -15,7 +15,6 @@ spec:
         image: quay.io/coreos/container-linux-update-operator:v0.2.2
         command:
         - "/bin/update-operator"
-        - "--manage-agent=false"
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/examples/update-operator.yaml.tmpl
+++ b/examples/update-operator.yaml.tmpl
@@ -15,7 +15,6 @@ spec:
         image: quay.io/coreos/container-linux-update-operator:v${VERSION}
         command:
         - "/bin/update-operator"
-        - "--manage-agent=false"
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
* Add update strategy so `kubectl apply` rolling updates if there is an existing daemonset
* By default, update-operator does not manage the update-agent daemonset so the custom label and annotation aren't needed.