### PR TITLE
update-operator: Require before and after reboot annotations

### DIFF
--- a/cmd/update-operator/main.go
+++ b/cmd/update-operator/main.go
@@ -15,6 +15,8 @@ import (
 )
 
 var (
+	beforeRebootAnnotations flagutil.StringSliceFlag
+	afterRebootAnnotations  flagutil.StringSliceFlag
 	kubeconfig              = flag.String("kubeconfig", "", "Path to a kubeconfig file. Default to the in-cluster config if not provided.")
 	analyticsEnabled        = flag.Bool("analytics", true, "Send analytics to Google Analytics")
 	autoLabelContainerLinux = flag.Bool("auto-label-container-linux", false, "Auto-label Container Linux nodes with agent=true (convenience)")
@@ -25,12 +27,16 @@ var (
 )
 
 func main() {
+	flag.Var(&beforeRebootAnnotations, "before-reboot-annotations", "List of comma-separated Kubernetes node annotations that must be set to 'true' before a reboot is allowed")
+	flag.Var(&afterRebootAnnotations, "after-reboot-annotations", "List of comma-separated Kubernetes node annotations that must be set to 'true' before a node is marked schedulable and the operator lock is released")
+
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
 	if err := flagutil.SetFlagsFromEnv(flag.CommandLine, "UPDATE_OPERATOR"); err != nil {
 		glog.Fatalf("Failed to parse environment variables: %v", err)
 	}
+
 	// respect KUBECONFIG without the prefix as well
 	if *kubeconfig == "" {
 		*kubeconfig = os.Getenv("KUBECONFIG")
@@ -61,6 +67,8 @@ func main() {
 		AutoLabelContainerLinux: *autoLabelContainerLinux,
 		ManageAgent:             *manageAgent,
 		AgentImageRepo:          *agentImageRepo,
+		BeforeRebootAnnotations: beforeRebootAnnotations,
+		AfterRebootAnnotations:  afterRebootAnnotations,
 	})
 	if err != nil {
 		glog.Fatalf("Failed to initialize %s: %v", os.Args[0], err)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -81,12 +81,6 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 		return fmt.Errorf("failed to set node info: %v", err)
 	}
 
-	// we are schedulable now.
-	glog.Info("Marking node as schedulable")
-	if err := k8sutil.Unschedulable(k.nc, k.node, false); err != nil {
-		return err
-	}
-
 	// set coreos.com/update1/reboot-in-progress=false and
 	// coreos.com/update1/reboot-needed=false
 	anno := map[string]string{
@@ -100,6 +94,12 @@ func (k *Klocksmith) process(stop <-chan struct{}) error {
 	// Since we set 'reboot-needed=false', 'ok-to-reboot' should clear.
 	// Wait for it to do so, else we might start reboot-looping
 	if err := k.waitForNotOkToReboot(); err != nil {
+		return err
+	}
+
+	// we are schedulable now.
+	glog.Info("Marking node as schedulable")
+	if err := k8sutil.Unschedulable(k.nc, k.node, false); err != nil {
 		return err
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -51,6 +51,11 @@ const (
 	// It is an opaque string, but might be semver.
 	AnnotationNewVersion = Prefix + "new-version"
 
+	// Keys set to true when the operator is waiting for configured annotation
+	// before and after the reboot repectively
+	LabelBeforeReboot = Prefix + "before-reboot"
+	LabelAfterReboot  = Prefix + "after-reboot"
+
 	// Key set by the update-agent to the value of "ID" in /etc/os-release.
 	LabelID = Prefix + "id"
 

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -80,6 +80,24 @@ func SetNodeAnnotations(nc v1core.NodeInterface, node string, m map[string]strin
 	})
 }
 
+// DeleteNodeLabels deletes all keys in ks
+func DeleteNodeLabels(nc v1core.NodeInterface, node string, ks []string) error {
+	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {
+		for _, k := range ks {
+			delete(n.Labels, k)
+		}
+	})
+}
+
+// DeleteNodeAnnotations deletes all annotations with keys in ks
+func DeleteNodeAnnotations(nc v1core.NodeInterface, node string, ks []string) error {
+	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {
+		for _, k := range ks {
+			delete(n.Annotations, k)
+		}
+	})
+}
+
 // Unschedulable marks node as schedulable or unschedulable according to sched.
 func Unschedulable(nc v1core.NodeInterface, node string, sched bool) error {
 	n, err := nc.Get(node, v1meta.GetOptions{})

--- a/pkg/k8sutil/selector.go
+++ b/pkg/k8sutil/selector.go
@@ -5,8 +5,19 @@ import (
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	v1api "k8s.io/client-go/pkg/api/v1"
 )
+
+// NewRequirementOrDie wraps a call to NewRequirement and panics if the Requirment
+// cannot be created. It is intended for use in variable initializations only.
+func NewRequirementOrDie(key string, op selection.Operator, vals []string) *labels.Requirement {
+	req, err := labels.NewRequirement(key, op, vals)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
 
 // FilterNodesByAnnotation takes a node list and a field selector, and returns
 // a node list that matches the field selector.

--- a/pkg/operator/agent_manager.go
+++ b/pkg/operator/agent_manager.go
@@ -30,21 +30,12 @@ var (
 	}
 
 	// Label Requirement matching nodes which lack the update agent label
-	updateAgentLabelMissing = MustRequirement(labels.NewRequirement(
+	updateAgentLabelMissing = k8sutil.NewRequirementOrDie(
 		constants.LabelUpdateAgentEnabled,
 		selection.DoesNotExist,
 		[]string{},
-	))
+	)
 )
-
-// MustRequirement wraps a call to NewRequirement and panics if the Requirment
-// cannot be created. It is intended for use in variable initializations only.
-func MustRequirement(req *labels.Requirement, err error) *labels.Requirement {
-	if err != nil {
-		panic(err)
-	}
-	return req
-}
 
 // legacyLabeler finds Container Linux nodes lacking the update-agent enabled
 // label and adds the label set "true" so nodes opt-in to running update-agent.

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/glog"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -63,21 +64,37 @@ var (
 	// it would like to reboot, and false when it starts up.
 	//
 	// If constants.AnnotationRebootPaused is set to "true", the update-agent will not consider it for rebooting.
-	wantsRebootSelector = fields.ParseSelectorOrDie(constants.AnnotationRebootNeeded + "==" + constants.True + "," + constants.AnnotationRebootPaused + "!=" + constants.True)
+	wantsRebootSelector = fields.ParseSelectorOrDie(constants.AnnotationRebootNeeded + "==" + constants.True +
+		"," + constants.AnnotationRebootPaused + "!=" + constants.True +
+		"," + constants.AnnotationOkToReboot + "!=" + constants.True +
+		"," + constants.AnnotationRebootInProgress + "!=" + constants.True)
 
 	// stillRebootingSelector is a selector for the annotation set expected to be
 	// on a node when it's in the process of rebooting
 	stillRebootingSelector = fields.Set(map[string]string{
-		constants.AnnotationOkToReboot:       constants.True,
-		constants.AnnotationRebootNeeded:     constants.True,
-		constants.AnnotationRebootInProgress: constants.True,
+		constants.AnnotationOkToReboot:   constants.True,
+		constants.AnnotationRebootNeeded: constants.True,
 	}).AsSelector()
+
+	// beforeRebootReq requires a node to be waiting for before reboot checks to complete
+	beforeRebootReq = k8sutil.NewRequirementOrDie(constants.LabelBeforeReboot, selection.In, []string{constants.True})
+
+	// afterRebootReq requires a node to be waiting for after reboot checks to complete
+	afterRebootReq = k8sutil.NewRequirementOrDie(constants.LabelAfterReboot, selection.In, []string{constants.True})
+
+	// notBeforeRebootReq and notAfterRebootReq are the inverse of the above checks
+	notBeforeRebootReq = k8sutil.NewRequirementOrDie(constants.LabelBeforeReboot, selection.NotIn, []string{constants.True})
+	notAfterRebootReq  = k8sutil.NewRequirementOrDie(constants.LabelAfterReboot, selection.NotIn, []string{constants.True})
 )
 
 type Kontroller struct {
 	kc kubernetes.Interface
 	nc v1core.NodeInterface
 	er record.EventRecorder
+
+	// annotations to look for before and after reboots
+	beforeRebootAnnotations []string
+	afterRebootAnnotations  []string
 
 	leaderElectionClient        clientset.Interface
 	leaderElectionEventRecorder record.EventRecorder
@@ -100,6 +117,9 @@ type Config struct {
 	Client kubernetes.Interface
 	// migration compatability
 	AutoLabelContainerLinux bool
+	// annotations to look for before and after reboots
+	BeforeRebootAnnotations []string
+	AfterRebootAnnotations  []string
 	// Deprecated
 	ManageAgent    bool
 	AgentImageRepo string
@@ -143,7 +163,19 @@ func New(config Config) (*Kontroller, error) {
 		return nil, fmt.Errorf("unable to determine operator namespace: please ensure POD_NAMESPACE environment variable is set")
 	}
 
-	return &Kontroller{kc, nc, er, leaderElectionClient, leaderElectionEventRecorder, namespace, config.AutoLabelContainerLinux, config.ManageAgent, config.AgentImageRepo}, nil
+	return &Kontroller{
+		kc: kc,
+		nc: nc,
+		er: er,
+		beforeRebootAnnotations:     config.BeforeRebootAnnotations,
+		afterRebootAnnotations:      config.AfterRebootAnnotations,
+		leaderElectionClient:        leaderElectionClient,
+		leaderElectionEventRecorder: leaderElectionEventRecorder,
+		namespace:                   namespace,
+		autoLabelContainerLinux:     config.AutoLabelContainerLinux,
+		manageAgent:                 config.ManageAgent,
+		agentImageRepo:              config.AgentImageRepo,
+	}, nil
 }
 
 // Run starts the operator reconcilitation proces and runs until the stop
@@ -241,122 +273,286 @@ func (k *Kontroller) withLeaderElection() error {
 func (k *Kontroller) process() {
 	glog.V(4).Info("Going through a loop cycle")
 
-	// update nodes which just rebooted
-	err := k.updateJustRebootedNodes()
+	// first make sure that all of our nodes are in a well-defined state with
+	// respect to our annotations and labels, and if they are not, then try to
+	// fix them.
+	glog.V(4).Info("Cleaning up node state")
+	err := k.cleanupState()
+	if err != nil {
+		glog.Errorf("Failed to cleanup node state: %v", err)
+		return
+	}
+
+	// find nodes with the after-reboot=true label and check if all provided
+	// annotations are set. if all annotations are set to true then remove the
+	// after-reboot=true label and set reboot-ok=false, telling the agent that
+	// the reboot has completed.
+	glog.V(4).Info("Checking if configured after-reboot annotations are set to true")
+	err = k.checkAfterReboot()
+	if err != nil {
+		glog.Errorf("Failed to check after reboot: %v", err)
+		return
+	}
+
+	// find nodes which just rebooted but haven't run after-reboot checks.
+	// remove after-reboot annotations and add the after-reboot=true label.
+	glog.V(4).Info("Labeling rebooted nodes with after-reboot label")
+	err = k.markAfterReboot()
 	if err != nil {
 		glog.Errorf("Failed to update recently rebooted nodes: %v", err)
 		return
 	}
 
-	// get all currently rebooting nodes
-	rebootingNodes, err := k.getRebootingNodes()
+	// find nodes with the before-reboot=true label and check if all provided
+	// annotations are set. if all annotations are set to true then remove the
+	// before-reboot=true label and set reboot=ok=true, telling the agent it's
+	// time to reboot.
+	glog.V(4).Info("Checking if configured before-reboot annotations are set to true")
+	err = k.checkBeforeReboot()
 	if err != nil {
-		glog.Errorf("Failed to get rebooting nodes: %v", err)
+		glog.Errorf("Failed to check before reboot: %v", err)
 		return
 	}
-	glog.V(6).Infof("Found %+v rebooting nodes", rebootingNodes)
 
-	// get all rebootable nodes
-	rebootableNodes, err := k.getRebootableNodes()
+	// take some number of the rebootable nodes. remove before-reboot
+	// annotations and add the before-reboot=true label.
+	glog.V(4).Info("Labeling rebootable nodes with before-reboot label")
+	err = k.markBeforeReboot()
 	if err != nil {
-		glog.Errorf("Failed to get rebootable nodes: %v", err)
+		glog.Errorf("Failed to update rebootable nodes: %v", err)
 		return
 	}
-	glog.V(6).Infof("Found %+v rebootable nodes", rebootableNodes)
-
-	// otherwise pick N of the eligible candidates to reboot
-	remainingRebootableCount := maxRebootingNodes - len(rebootingNodes)
-	// markSomeNodesRebootable returns immediately if len(rebootableNodes) == 0
-	k.markSomeNodesRebootable(rebootableNodes, remainingRebootableCount)
 }
 
-func (k *Kontroller) updateJustRebootedNodes() error {
+// cleanupState attempts to make sure nodes are in a well-defined state before
+// performing state changes on them.
+// If there is an error getting the list of nodes or updating any of them, an
+// error is immediately returned.
+func (k *Kontroller) cleanupState() error {
 	nodelist, err := k.nc.List(v1meta.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("Failed listing nodes %v", err)
+		return fmt.Errorf("Failed listing nodes: %v", err)
 	}
 
-	// find nodes which just rebooted
-	justRebootedNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, justRebootedSelector)
-
-	if len(justRebootedNodes) > 0 {
-		glog.Infof("Found %d rebooted nodes, setting annotation %q to false", len(justRebootedNodes), constants.AnnotationOkToReboot)
-	}
-
-	// for all the nodes which just rebooted, set reboot-ok=true
-	for _, n := range justRebootedNodes {
-		glog.Infof("Setting 'ok-to-reboot=false' for %q", n.Name)
-		if err := k8sutil.SetNodeAnnotations(k.nc, n.Name, map[string]string{
-			constants.AnnotationOkToReboot: constants.False,
-		}); err != nil {
-			glog.Infof("Failed setting annotation %q on node %q to false: %v", constants.AnnotationOkToReboot, n.Name, err)
-			return err
+	for _, n := range nodelist.Items {
+		err = k8sutil.UpdateNodeRetry(k.nc, n.Name, func(node *v1api.Node) {
+			// make sure that nodes with the before-reboot label actually
+			// still wants to reboot
+			if _, exists := node.Labels[constants.LabelBeforeReboot]; exists {
+				if !wantsRebootSelector.Matches(fields.Set(node.Annotations)) {
+					glog.Warningf("Node %v no longer wanted to reboot while we were trying to label it so: %v", node.Name, node.Annotations)
+					delete(node.Labels, constants.LabelBeforeReboot)
+					for _, annotation := range k.beforeRebootAnnotations {
+						delete(node.Annotations, annotation)
+					}
+				}
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("Failed to cleanup node %q: %v", n.Name, err)
 		}
 	}
 
 	return nil
 }
 
-func (k *Kontroller) getRebootableNodes() ([]v1api.Node, error) {
+// checkBeforeReboot gets all nodes with the before-reboot=true label and checks
+// if all of the configured before-reboot annotations are set to true. If they
+// are, it deletes the before-reboot=true label and sets reboot-ok=true to tell
+// the agent that it is ready to start the actual reboot process.
+// If it goes to set reboot-ok=true and finds that the node no longer wants a
+// reboot, then it just deletes the before-reboot=true label.
+// If there is an error getting the list of nodes or updating any of them, an
+// error is immediately returned.
+func (k *Kontroller) checkBeforeReboot() error {
 	nodelist, err := k.nc.List(v1meta.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Failed listing nodes %v", err)
+		return fmt.Errorf("Failed listing nodes: %v", err)
 	}
 
-	rebootableNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, wantsRebootSelector)
+	preRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, beforeRebootReq)
 
-	return rebootableNodes, nil
+	for _, n := range preRebootNodes {
+		if hasAllAnnotations(n, k.beforeRebootAnnotations) {
+			glog.V(4).Infof("Deleting label %q for %q", constants.LabelBeforeReboot, n.Name)
+			glog.V(4).Infof("Setting annotation %q to true for %q", constants.AnnotationOkToReboot, n.Name)
+			err = k8sutil.UpdateNodeRetry(k.nc, n.Name, func(node *v1api.Node) {
+				delete(node.Labels, constants.LabelBeforeReboot)
+				// cleanup the before-reboot annotations
+				for _, annotation := range k.beforeRebootAnnotations {
+					glog.V(4).Info("Deleting annotation %q from node %q", annotation, node.Name)
+					delete(node.Annotations, annotation)
+				}
+				node.Annotations[constants.AnnotationOkToReboot] = constants.True
+			})
+			if err != nil {
+				return fmt.Errorf("Failed to update node %q: %v", n.Name, err)
+			}
+		}
+	}
+
+	return nil
 }
 
-func (k *Kontroller) getRebootingNodes() ([]v1api.Node, error) {
+// checkAfterReboot gets all nodes with the after-reboot=true label and checks
+// if  all of the configured after-reboot annotations are set to true. If they
+// are, it deletes the after-reboot=true label and sets reboot-ok=false to tell
+// the agent that it has completed it's reboot successfully.
+// If there is an error getting the list of nodes or updating any of them, an
+// error is immediately returned.
+func (k *Kontroller) checkAfterReboot() error {
 	nodelist, err := k.nc.List(v1meta.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Failed listing nodes %v", err)
+		return fmt.Errorf("Failed listing nodes: %v", err)
 	}
 
-	rebootingNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, stillRebootingSelector)
+	postRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, afterRebootReq)
 
-	// Verify no nodes are still in the process of rebooting to avoid rebooting N > maxRebootingNodes
+	for _, n := range postRebootNodes {
+		if hasAllAnnotations(n, k.afterRebootAnnotations) {
+			glog.V(4).Infof("Deleting label %q for %q", constants.LabelAfterReboot, n.Name)
+			glog.V(4).Infof("Setting annotation %q to false for %q", constants.AnnotationOkToReboot, n.Name)
+			err = k8sutil.UpdateNodeRetry(k.nc, n.Name, func(node *v1api.Node) {
+				delete(node.Labels, constants.LabelAfterReboot)
+				// cleanup the after-reboot annotations
+				for _, annotation := range k.afterRebootAnnotations {
+					glog.V(4).Info("Deleting annotation %q from node %q", annotation, node.Name)
+					delete(node.Annotations, annotation)
+				}
+				node.Annotations[constants.AnnotationOkToReboot] = constants.False
+			})
+			if err != nil {
+				return fmt.Errorf("Failed to update node %q: %v", n.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// markBeforeReboot gets nodes which want to reboot and marks them with the
+// before-reboot=true label. This is considered the beginning of the reboot
+// process from the perspective of the update-operator. It will only mark
+// nodes with this label up to the maximum number of concurrently rebootable
+// nodes as configured with the maxRebootingNodes constant.
+// It cleans up the before-reboot annotations before it applies the label, in
+// case there are any left over from the last reboot.
+// If there is an error getting the list of nodes or updating any of them, an
+// error is immediately returned.
+func (k *Kontroller) markBeforeReboot() error {
+	nodelist, err := k.nc.List(v1meta.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed listing nodes: %v", err)
+	}
+
+	// find nodes which are still rebooting
+	rebootingNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, stillRebootingSelector)
+	// nodes running before and after reboot checks are still considered to be "rebooting" to us
+	beforeRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, beforeRebootReq)
+	rebootingNodes = append(rebootingNodes, beforeRebootNodes...)
+	afterRebootNodes := k8sutil.FilterNodesByRequirement(nodelist.Items, afterRebootReq)
+	rebootingNodes = append(rebootingNodes, afterRebootNodes...)
+
+	// Verify the number of currently rebooting nodes is less than the the maximum number
 	if len(rebootingNodes) >= maxRebootingNodes {
 		for _, n := range rebootingNodes {
 			glog.Infof("Found node %q still rebooting, waiting", n.Name)
 		}
-		return nil, fmt.Errorf("Found %d (of max %d) rebooting nodes; waiting for completion", len(rebootingNodes), maxRebootingNodes)
+		glog.Infof("Found %d (of max %d) rebooting nodes; waiting for completion", len(rebootingNodes), maxRebootingNodes)
+		return nil
 	}
 
-	return rebootingNodes, nil
-}
+	// find nodes which want to reboot
+	rebootableNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, wantsRebootSelector)
+	rebootableNodes = k8sutil.FilterNodesByRequirement(rebootableNodes, notBeforeRebootReq)
 
-func (k *Kontroller) markSomeNodesRebootable(rebootableNodes []v1api.Node, remainingRebootableCount int) {
 	// Don't even bother if rebootableNodes is empty. We wouldn't do anything anyway.
 	if len(rebootableNodes) == 0 {
-		return
+		return nil
 	}
 
+	// find the number of nodes we can tell to reboot
+	remainingRebootableCount := maxRebootingNodes - len(rebootingNodes)
+
+	// choose some number of nodes
 	chosenNodes := make([]*v1api.Node, 0, remainingRebootableCount)
 	for i := 0; i < remainingRebootableCount && i < len(rebootableNodes); i++ {
 		chosenNodes = append(chosenNodes, &rebootableNodes[i])
 	}
 
-	// mark the chosen nodes as rebootable
+	// set before-reboot=true for the chosen nodes
 	glog.Infof("Found %d nodes that need a reboot", len(chosenNodes))
-	for _, node := range chosenNodes {
-		k.markNodeRebootable(node)
+	for _, n := range chosenNodes {
+		err = k.mark(n.Name, constants.LabelBeforeReboot, k.beforeRebootAnnotations)
+		if err != nil {
+			return fmt.Errorf("Failed to label node for before reboot checks: %v", err)
+		}
+		if len(k.beforeRebootAnnotations) > 0 {
+			glog.Infof("Waiting for before-reboot annotations on node %q: %v", n.Name, k.afterRebootAnnotations)
+		}
 	}
+
+	return nil
 }
 
-// markNodeRebootable adds ok to reboot annotations to the given node.
-func (k *Kontroller) markNodeRebootable(n *v1api.Node) {
-	glog.Infof("Marking %q ok to reboot", n.Name)
-	if err := k8sutil.UpdateNodeRetry(k.nc, n.Name, func(node *v1api.Node) {
-		if !wantsRebootSelector.Matches(fields.Set(node.Annotations)) {
-			glog.Warningf("Node %v no longer wanted to reboot while we were trying to mark it so: %v", node.Name, node.Annotations)
-			return
-		}
-
-		node.Annotations[constants.AnnotationOkToReboot] = constants.True
-	}); err != nil {
-		glog.Infof("Failed to set annotation %q on node %q: %v", constants.AnnotationOkToReboot, n.Name, err)
-		return
+// markAfterReboot gets nodes which have completed rebooting and marks them with
+// the after-reboot=true label. A node with the after-reboot=true label is still
+// considered to be rebooting from the perspective of the update-operator, even
+// though it has completed rebooting from the machines perspective.
+// It cleans up the after-reboot annotations before it applies the label, in
+// case there are any left over from the last reboot.
+// If there is an error getting the list of nodes or updating any of them, an
+// error is immediately returned.
+func (k *Kontroller) markAfterReboot() error {
+	nodelist, err := k.nc.List(v1meta.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("Failed listing nodes: %v", err)
 	}
+
+	// find nodes which just rebooted
+	justRebootedNodes := k8sutil.FilterNodesByAnnotation(nodelist.Items, justRebootedSelector)
+	// also filter out any nodes that are already labeled with after-reboot=true
+	justRebootedNodes = k8sutil.FilterNodesByRequirement(justRebootedNodes, notAfterRebootReq)
+
+	glog.Infof("Found %d rebooted nodes, setting label %q to %q", len(justRebootedNodes), constants.LabelAfterReboot, constants.True)
+
+	// for all the nodes which just rebooted, remove any old annotations and add the after-reboot=true label
+	for _, n := range justRebootedNodes {
+		err = k.mark(n.Name, constants.LabelAfterReboot, k.afterRebootAnnotations)
+		if err != nil {
+			return fmt.Errorf("Failed to label node for after reboot checks: %v", err)
+		}
+		if len(k.afterRebootAnnotations) > 0 {
+			glog.Infof("Waiting for after-reboot annotations on node %q: %v", n.Name, k.afterRebootAnnotations)
+		}
+	}
+
+	return nil
+}
+
+func (k *Kontroller) mark(nodeName string, label string, annotations []string) error {
+	glog.V(4).Infof("Deleting annotations %v for %q", annotations, nodeName)
+	glog.V(4).Infof("Setting label %q to %q for node %q", label, constants.True, nodeName)
+	err := k8sutil.UpdateNodeRetry(k.nc, nodeName, func(node *v1api.Node) {
+		for _, annotation := range annotations {
+			delete(node.Annotations, annotation)
+		}
+		node.Labels[label] = constants.True
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to set %q to %q on node %q: %v", label, constants.True, nodeName, err)
+	}
+
+	return nil
+}
+
+func hasAllAnnotations(node v1api.Node, annotations []string) bool {
+	nodeAnnotations := node.GetAnnotations()
+	for _, annotation := range annotations {
+		value, ok := nodeAnnotations[annotation]
+		if !ok || value != constants.True {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
This pr adds pre- and post-reboot actions.

With these changes, you will be able to configure actions which get run before a reboot is initiated and after one is completed, effectively gating it on either side. The actions taken are entirely arbitrary, and software that implements them only needs to be able to manipulate kubernetes annotations and read labels.

The changes to the `update-operator` ended up being a little more of an overhaul than I originally intended. With the addition of the new behavior, the `update-operator` has, broadly speaking, four state changes which it is responsible for. Those changes are
1. Find nodes where the post-reboot actions are completed successfully mark everything ready to go
2. Find nodes which have just rebooted and initiate post-reboot actions on them
3. Find nodes where the pre-reboot actions are completed successfully and tell them to reboot
4. Find nodes which want to reboot and initiate pre-reboot actions on them

I broke the process function out into four functions, one for each of those state changes, to make it easier to understand, validate, and modify in the future. 

The `update-agent` has been modified not to mark a node schedulable until the post-reboot actions are complete. Currently, the node continues to be marked as scheduled until it starts draining, which is after the pre-reboot actions are run. It is possible to modify it to mark it as unschedulable while running pre-reboot actions, but it would require more work and I don't think it's necessary to do that. If someone can think of a good reason to mark it unschedulable please disagree with me. 

I will include documentation around the usage in a separate pr, as well as examples. 