### PR TITLE
Add annotation to exclude nodes from being schedulable 

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -51,6 +51,12 @@ const (
 	// It is an opaque string, but might be semver.
 	AnnotationNewVersion = Prefix + "new-version"
 
+	// Key set by the administrator to mark a node as default unschedulable.
+	// Never set by the update-agent or update-operator.
+	//
+	// Prevents update-agent from marking SchedulingDisabled nodes Schedulable.
+	AnnotationSchedulingDisabled = Prefix + "scheduling-disabled"
+
 	// Key set by the update-agent to the value of "ID" in /etc/os-release.
 	LabelID = Prefix + "id"
 

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -80,6 +80,16 @@ func SetNodeAnnotations(nc v1core.NodeInterface, node string, m map[string]strin
 	})
 }
 
+// MatchNodeAnnotations matches a given selector to a node's
+// annotations.
+func MatchNodeAnnotations(nc v1core.NodeInterface, node string, selector fields.Selector) (bool, error) {
+	n, err := nc.Get(node, v1meta.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return selector.Matches(fields.Set(n.Annotations)), nil
+}
+
 // Unschedulable marks node as schedulable or unschedulable according to sched.
 func Unschedulable(nc v1core.NodeInterface, node string, sched bool) error {
 	n, err := nc.Get(node, v1meta.GetOptions{})


### PR DESCRIPTION
This PR introduces a new annotation that cluster admins can add to specific nodes to prevent them from being "Schedulable" by the agent. This is specially useful when you have certain nodes that only run master components (ie: `node-role.kubernetes.io/master=true`) and want them to participate in the update orchestration. 
