### PR TITLE
operator: output correct beforeReboot annotation

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -488,7 +488,7 @@ func (k *Kontroller) markBeforeReboot() error {
 			return fmt.Errorf("Failed to label node for before reboot checks: %v", err)
 		}
 		if len(k.beforeRebootAnnotations) > 0 {
-			glog.Infof("Waiting for before-reboot annotations on node %q: %v", n.Name, k.afterRebootAnnotations)
+			glog.Infof("Waiting for before-reboot annotations on node %q: %v", n.Name, k.beforeRebootAnnotations)
 		}
 	}
 


### PR DESCRIPTION
When waiting for the before-reboot annotation, the operator outputs the incorrect annotation (`afterRebootAnnotations`). This fixes the log output to avoid confusion