### PR TITLE
examples/operator: add tolerations to run on master

### DIFF
--- a/examples/update-operator.yaml
+++ b/examples/update-operator.yaml
@@ -20,3 +20,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule


### PR DESCRIPTION
This updates the CLUO example manifest to tolerate running on master
nodes.