### PR TITLE
update-agent: wait for pods to terminate before rebooting

### DIFF
--- a/cmd/update-agent/main.go
+++ b/cmd/update-agent/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/coreos/pkg/flagutil"
 	"github.com/golang/glog"
@@ -15,6 +16,7 @@ import (
 var (
 	node         = flag.String("node", "", "Kubernetes node name")
 	printVersion = flag.Bool("version", false, "Print version and exit")
+	reapTimeout  = flag.Int("grace-period", 600, "Period of time in seconds given to a pod to terminate when rebooting for an update")
 )
 
 func main() {
@@ -34,7 +36,8 @@ func main() {
 		glog.Fatal("-node is required")
 	}
 
-	a, err := agent.New(*node)
+	rt := time.Duration(*reapTimeout) * time.Second
+	a, err := agent.New(*node, rt)
 	if err != nil {
 		glog.Fatalf("Failed to initialize %s: %v", os.Args[0], err)
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -22,16 +22,15 @@ import (
 )
 
 type Klocksmith struct {
-	node string
-	kc   kubernetes.Interface
-	nc   v1core.NodeInterface
-	ue   *updateengine.Client
-	lc   *login1.Conn
-	ri   time.Duration
-	rt   time.Duration
+	node        string
+	kc          kubernetes.Interface
+	nc          v1core.NodeInterface
+	ue          *updateengine.Client
+	lc          *login1.Conn
+	reapTimeout time.Duration
 }
 
-const reapInterval = 10 * time.Second
+const defaultPollInterval = 10 * time.Second
 
 var (
 	shouldRebootSelector = fields.Set(map[string]string{
@@ -62,7 +61,7 @@ func New(node string, reapTimeout time.Duration) (*Klocksmith, error) {
 		return nil, fmt.Errorf("error establishing connection to logind dbus: %v", err)
 	}
 
-	return &Klocksmith{node, kc, nc, ue, lc, reapInterval, reapTimeout}, nil
+	return &Klocksmith{node, kc, nc, ue, lc, reapTimeout}, nil
 }
 
 // Run starts the agent to listen for an update_engine reboot signal and react
@@ -198,7 +197,7 @@ func (k *Klocksmith) updateStatusCallback(s updateengine.Status) {
 		anno[constants.AnnotationRebootNeeded] = constants.True
 	}
 
-	wait.PollUntil(10*time.Second, func() (bool, error) {
+	wait.PollUntil(defaultPollInterval, func() (bool, error) {
 		if err := k8sutil.SetNodeAnnotations(k.nc, k.node, anno); err != nil {
 			glog.Errorf("Failed to set annotation %q: %v", constants.AnnotationStatus, err)
 			return false, nil
@@ -361,7 +360,7 @@ func (k *Klocksmith) getPodsForDeletion() ([]v1.Pod, error) {
 
 // waitForPodDeletion waits for a pod to be deleted
 func (k *Klocksmith) waitForPodDeletion(pod v1.Pod) error {
-	return wait.PollImmediate(k.ri, k.rt, func() (bool, error) {
+	return wait.PollImmediate(defaultPollInterval, k.reapTimeout, func() (bool, error) {
 		_, err := k.kc.CoreV1().Pods(pod.Namespace).Get(pod.Name, v1meta.GetOptions{})
 		if errors.IsNotFound(err) {
 			glog.Infof("Deleted pod %q", pod.Name)


### PR DESCRIPTION
This change makes the agent wait until all pods are terminated before rebooting. Prior to this change, the agent would reboot immediately after the pod delete request was made and, consequently, pods were not given the time needed to terminate gracefully.