### PR TITLE
Change RBAC ClusterRole for CLUO v0.4.0

### DIFF
--- a/examples/cluster-role.yaml
+++ b/examples/cluster-role.yaml
@@ -15,7 +15,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - endpoints
+      - configmaps
     verbs:
       - create
       - get


### PR DESCRIPTION
* Update the RBAC examples shortly before releasing v0.4.0
* #140 switches from endpoint-based leader election to configmap-based leader election