### PR TITLE
examples: Add RBAC permission to get individual pods

### DIFF
--- a/examples/cluster-role.yaml
+++ b/examples/cluster-role.yaml
@@ -34,6 +34,7 @@ rules:
     resources:
       - pods
     verbs:
+      - get
       - list
       - delete      
   - apiGroups:


### PR DESCRIPTION
When #137 was merged, it adds code to get each pod (rather than list) to determine whether it was successfully deleted. This requires an appropriate RBAC grant. Otherwise, having a grace period max is all that keeps it from stalling forever.