### PR TITLE
pkg/agent: Consider NotFound or changed UID pods deleted

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -361,8 +361,8 @@ func (k *Klocksmith) getPodsForDeletion() ([]v1.Pod, error) {
 // waitForPodDeletion waits for a pod to be deleted
 func (k *Klocksmith) waitForPodDeletion(pod v1.Pod) error {
 	return wait.PollImmediate(defaultPollInterval, k.reapTimeout, func() (bool, error) {
-		_, err := k.kc.CoreV1().Pods(pod.Namespace).Get(pod.Name, v1meta.GetOptions{})
-		if errors.IsNotFound(err) {
+		p, err := k.kc.CoreV1().Pods(pod.Namespace).Get(pod.Name, v1meta.GetOptions{})
+		if errors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
 			glog.Infof("Deleted pod %q", pod.Name)
 			return true, nil
 		}


### PR DESCRIPTION
Borrowed from https://github.com/kubernetes/kubernetes/blob/v1.8.1/pkg/kubectl/cmd/drain.go#L565-L585

rel: #137 
Closes #149