### PR TITLE
 agent: set a label when after successful os-update 

### DIFF
--- a/doc/labels-and-annotations.md
+++ b/doc/labels-and-annotations.md
@@ -30,12 +30,13 @@ A few labels may be set directly by admins to customize behavior. These are call
 | id   | coreos  |  update-agent    | Reflects the ID in `/etc/os-release` |
 | version | 1497.7.0 | update-agent | Reflects the VERSION in `/etc/os-release` |
 | group | stable | update-agent     | Reflects the GROUP in `/usr/share/coreos/update.conf` or `/etc/coreos/update.conf` |
+| reboot-needed | true | update-agent | Reflects the reboot-needed annotation |
 
 **Annotations**
 
 | name | example | setter           | description |
 |------|---------|------------------|-------------|
-| reboot-needed  | true/false | update-agent | Set to true to request a coordinated reboot |
+| reboot-needed  | true/false | update-agent | Updates to true to request a coordinated reboot from the operator |
 | reboot-in-progress | true/false | update-agent | Set to true to indicate a reboot is in progress |
 | status | UPDATE_STATUS_IDLE | update-agent | Reflects the `update_engine` CurrentOperation status value |
 | new-version       | 0.0.0      | update-agent | Reflects the `update_engine` NewVersion status value |

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,6 +12,7 @@ const (
 
 	// Key set to "true" by the update-agent when a reboot is requested.
 	AnnotationRebootNeeded = Prefix + "reboot-needed"
+	LabelRebootNeeded      = Prefix + "reboot-needed"
 
 	// Key set to "true" by the update-agent when node-drain and reboot is
 	// initiated.

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -80,6 +80,20 @@ func SetNodeAnnotations(nc v1core.NodeInterface, node string, m map[string]strin
 	})
 }
 
+// SetNodeAnnotationsLabels sets all keys in a and l to their respective values in
+// node's annotations and labels, likewise
+func SetNodeAnnotationsLabels(nc v1core.NodeInterface, node string, a, l map[string]string) error {
+	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {
+		for k, v := range a {
+			n.Annotations[k] = v
+		}
+
+		for k, v := range l {
+			n.Labels[k] = v
+		}
+	})
+}
+
 // DeleteNodeLabels deletes all keys in ks
 func DeleteNodeLabels(nc v1core.NodeInterface, node string, ks []string) error {
 	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -80,8 +80,8 @@ func SetNodeAnnotations(nc v1core.NodeInterface, node string, m map[string]strin
 	})
 }
 
-// SetNodeAnnotationsLabels sets all keys in a and l to their respective values in
-// node's annotations and labels, likewise
+// SetNodeAnnotationsLabels sets all keys in a and l to their values in
+// node's annotations and labels, respectively
 func SetNodeAnnotationsLabels(nc v1core.NodeInterface, node string, a, l map[string]string) error {
 	return UpdateNodeRetry(nc, node, func(n *v1api.Node) {
 		for k, v := range a {


### PR DESCRIPTION
agent: set a label when after successful os-update
    
This sets the label `container-linux-update.v1.coreos.com/os-update-staged: "true"` on nodes where the OS has been upgraded but not yet rebooted. This is so daemonsets like tectonic-torcx can run ASAP.
    
Fixes: #167