### PR TITLE
Only Mark Node Schedulable If Agent Marked Unschedulable 

### DIFF
--- a/doc/labels-and-annotations.md
+++ b/doc/labels-and-annotations.md
@@ -41,3 +41,4 @@ A few labels may be set directly by admins to customize behavior. These are call
 | status | UPDATE_STATUS_IDLE | update-agent | Reflects the `update_engine` CurrentOperation status value |
 | new-version       | 0.0.0      | update-agent | Reflects the `update_engine` NewVersion status value |
 | last-checked-time | 1501621307 | update-agent | Reflects the `update_engine` LastCheckedTime status value |
+| agent-made-unschedulable | true/false | update-agent | Indicates if the agent made the node unschedulable. If false, something other than the agent made the node unschedulable |

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,6 +52,9 @@ const (
 	// It is an opaque string, but might be semver.
 	AnnotationNewVersion = Prefix + "new-version"
 
+	// Ket set by update-agent to indicate it was responsible for making node unschedulable
+	AnnotationAgentMadeUnschedulable = Prefix + "agent-made-unschedulable"
+
 	// Keys set to true when the operator is waiting for configured annotation
 	// before and after the reboot repectively
 	LabelBeforeReboot = Prefix + "before-reboot"

--- a/pkg/k8sutil/metadata.go
+++ b/pkg/k8sutil/metadata.go
@@ -35,6 +35,22 @@ func NodeAnnotationCondition(selector fields.Selector) watch.ConditionFunc {
 	}
 }
 
+// GetNodeRetry gets a node object, retrying up to DefaultBackoff number of times if it fails
+func GetNodeRetry(nc v1core.NodeInterface, node string) (*v1api.Node, error) {
+	var apiNode *v1api.Node
+	err := RetryOnError(DefaultBackoff, func() error {
+		n, getErr := nc.Get(node, v1meta.GetOptions{})
+		if getErr != nil {
+			return fmt.Errorf("failed to get node %q: %v", node, getErr)
+		}
+
+		apiNode = n
+		return nil
+	})
+
+	return apiNode, err
+}
+
 // UpdateNodeRetry calls f to update a node object in Kubernetes.
 // It will attempt to update the node by applying f to it up to DefaultBackoff
 // number of times.

--- a/pkg/k8sutil/retry.go
+++ b/pkg/k8sutil/retry.go
@@ -79,3 +79,21 @@ func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
 	}
 	return err
 }
+
+// RetryOnError retries a function repeatedly with the specified backoff until it succeeds or times out
+func RetryOnError(backoff wait.Backoff, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		lastErr := fn()
+		if lastErr == nil {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}

--- a/pkg/k8sutil/retry.go
+++ b/pkg/k8sutil/retry.go
@@ -85,11 +85,8 @@ func RetryOnError(backoff wait.Backoff, fn func() error) error {
 	var lastErr error
 	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		lastErr := fn()
-		if lastErr == nil {
-			return true, nil
-		}
 
-		return false, nil
+		return lastErr == nil, nil
 	})
 
 	if err == wait.ErrWaitTimeout {


### PR DESCRIPTION
This PR changes the agent to mark a node schedulable only if the agent was responsible for marking it unschedulable.

Prior to this change, the agent would always mark a node as schedulable when starting up. This could result in a node that had been marked unschedulable by an external process (eg. by an admin using kubectl) being marked schedulable by it's update agent if the agent restarted for some reason. 